### PR TITLE
Fix icon and text colour for dark mode

### DIFF
--- a/lib/utils/theme_config.dart
+++ b/lib/utils/theme_config.dart
@@ -162,90 +162,90 @@ enum MyTheme { Light, Dark }
 class ThemeNotifier extends ChangeNotifier {
   static List<ThemeData> themes = [
     ThemeData(
-      visualDensity: VisualDensity.adaptivePlatformDensity,
-      inputDecorationTheme: InputDecorationTheme(
-        hintStyle: TextStyle(
-          color: Color(0xff393E46),
+        visualDensity: VisualDensity.adaptivePlatformDensity,
+        inputDecorationTheme: InputDecorationTheme(
+          hintStyle: TextStyle(
+            color: Color(0xff393E46),
+          ),
+          filled: true,
+          fillColor: Color(0xffeeeeee),
+          hoverColor: Colors.white,
+          alignLabelWithHint: true,
+          border: InputBorder.none,
+          enabledBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.all(Radius.circular(50.0)),
+            borderSide: BorderSide(color: Color(00000000)),
+          ),
+          focusedBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.all(Radius.circular(50.0)),
+            borderSide: BorderSide(color: Color(00000000)),
+          ),
         ),
-        filled: true,
-        fillColor: Color(0xffeeeeee),
-        hoverColor: Colors.white,
-        alignLabelWithHint: true,
-        border: InputBorder.none,
-        enabledBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.all(Radius.circular(50.0)),
-          borderSide: BorderSide(color: Color(00000000)),
-        ),
-        focusedBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.all(Radius.circular(50.0)),
-          borderSide: BorderSide(color: Color(00000000)),
-        ),
-      ),
-      bottomAppBarTheme: BottomAppBarTheme(
-        color: Colors.white,
-        elevation: 0,
-      ),
-      appBarTheme: AppBarTheme(
-        color: Colors.white,
-        elevation: 0,
-        brightness: Brightness.light,
-        centerTitle: true,
-        iconTheme: IconThemeData(
-          color: Colors.black,
-        ),
-      ),
-      primaryColor: Color(0xff00adb5),
-      primaryColorLight: Color(0xff00adb5),
-      accentColor: Color(0xff393e46),
-      buttonColor: Color(0xffeeeeee),
-      scaffoldBackgroundColor: Colors.white,
-      bottomAppBarColor: Colors.white,
-      fontFamily: 'Montserrat',
-      brightness: Brightness.light,
-      primaryColorBrightness: Brightness.light,
-    ),
-    ThemeData(
-      visualDensity: VisualDensity.adaptivePlatformDensity,
-      appBarTheme: AppBarTheme(
-          color: Colors.black26,
+        bottomAppBarTheme: BottomAppBarTheme(
+          color: Colors.white,
           elevation: 0,
-          brightness: Brightness.dark,
+        ),
+        appBarTheme: AppBarTheme(
+          color: Colors.white,
+          elevation: 0,
+          brightness: Brightness.light,
           centerTitle: true,
           iconTheme: IconThemeData(
-            color: Colors.white,
+            color: Colors.black,
           ),
-          actionsIconTheme: IconThemeData(
-            color: Colors.white,
-          )),
-      inputDecorationTheme: InputDecorationTheme(
-        hintStyle: TextStyle(
-          color: Color(0xff333333),
         ),
-        filled: true,
-        fillColor: Colors.black,
-        alignLabelWithHint: true,
-        border: InputBorder.none,
-        enabledBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.all(Radius.circular(50.0)),
-          borderSide: BorderSide(color: Color(00000000)),
+        primaryColor: Color(0xff00adb5),
+        primaryColorLight: Color(0xff00adb5),
+        accentColor: Color(0xff393e46),
+        buttonColor: Color(0xffeeeeee),
+        scaffoldBackgroundColor: Colors.white,
+        bottomAppBarColor: Colors.white,
+        fontFamily: 'Montserrat',
+        brightness: Brightness.light,
+        primaryColorBrightness: Brightness.light,
+        backgroundColor: Color(0xff393E46)),
+    ThemeData(
+        visualDensity: VisualDensity.adaptivePlatformDensity,
+        appBarTheme: AppBarTheme(
+            color: Colors.black26,
+            elevation: 0,
+            brightness: Brightness.dark,
+            centerTitle: true,
+            iconTheme: IconThemeData(
+              color: Colors.white,
+            ),
+            actionsIconTheme: IconThemeData(
+              color: Colors.white,
+            )),
+        inputDecorationTheme: InputDecorationTheme(
+          hintStyle: TextStyle(
+            color: Color(0xff333333),
+          ),
+          filled: true,
+          fillColor: Colors.black,
+          alignLabelWithHint: true,
+          border: InputBorder.none,
+          enabledBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.all(Radius.circular(50.0)),
+            borderSide: BorderSide(color: Color(00000000)),
+          ),
+          focusedBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.all(Radius.circular(50.0)),
+            borderSide: BorderSide(color: Color(00000000)),
+          ),
         ),
-        focusedBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.all(Radius.circular(50.0)),
-          borderSide: BorderSide(color: Color(00000000)),
+        primaryColor: Color(0xff00adb5),
+        primaryColorLight: Color(0xff00adb5),
+        accentColor: Color(0xff393e46),
+        buttonColor: Color(0xffeeeeee),
+        bottomNavigationBarTheme: BottomNavigationBarThemeData(
+          backgroundColor: Colors.black45,
+          elevation: 10,
+          selectedItemColor: Color(0xff00adb5),
         ),
-      ),
-      primaryColor: Color(0xff00adb5),
-      primaryColorLight: Color(0xff00adb5),
-      accentColor: Color(0xff393e46),
-      buttonColor: Color(0xffeeeeee),
-      bottomNavigationBarTheme: BottomNavigationBarThemeData(
-        backgroundColor: Colors.black45,
-        elevation: 10,
-        selectedItemColor: Color(0xff00adb5),
-      ),
-      fontFamily: 'Montserrat',
-      brightness: Brightness.dark,
-    ),
+        fontFamily: 'Montserrat',
+        brightness: Brightness.dark,
+        backgroundColor: Colors.white),
   ];
 
   MyTheme _current = MyTheme.Light;
@@ -261,7 +261,7 @@ class ThemeNotifier extends ChangeNotifier {
 
   get myTheme => _current;
 
-  get currentTheme => _currentTheme;
+  ThemeData get currentTheme => _currentTheme;
 
   void switchTheme() => _current == MyTheme.Light
       ? currentTheme = MyTheme.Dark

--- a/lib/view/home.dart
+++ b/lib/view/home.dart
@@ -4,6 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter_icons/flutter_icons.dart';
 import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+import '../utils/theme_config.dart';
 
 class Home extends StatefulWidget {
   @override
@@ -130,7 +132,7 @@ class _HomeState extends State<Home> {
     ];
   }
 
-  Widget feed() {
+  Widget feed({ThemeNotifier theme}) {
     return StreamBuilder(
       stream: currentFeed,
       builder: (context, asyncSnapshot) {
@@ -184,15 +186,24 @@ class _HomeState extends State<Home> {
                               leading: Icon(
                                 sportIcon,
                                 size: 48,
+                                color: theme.currentTheme.backgroundColor,
                               ),
-                              title: Text(asyncSnapshot.data.documents[index]
-                                  .get('eventName')),
+                              title: Text(
+                                asyncSnapshot.data.documents[index]
+                                    .get('eventName'),
+                                style: TextStyle(
+                                  color: theme.currentTheme.backgroundColor,
+                                ),
+                              ),
                               subtitle: Column(
                                 crossAxisAlignment: CrossAxisAlignment.start,
                                 children: [
                                   Text(
                                     asyncSnapshot.data.documents[index]
                                         .get('description'),
+                                    style: TextStyle(
+                                      color: theme.currentTheme.backgroundColor,
+                                    ),
                                   ),
                                   Row(
                                     children: [
@@ -257,6 +268,7 @@ class _HomeState extends State<Home> {
 
   @override
   Widget build(BuildContext context) {
+    final ThemeNotifier theme = Provider.of<ThemeNotifier>(context);
     return Scaffold(
       appBar: new AppBar(
         automaticallyImplyLeading: false,
@@ -294,7 +306,7 @@ class _HomeState extends State<Home> {
             ),
             Expanded(
               child: Stack(
-                children: <Widget>[feed()],
+                children: <Widget>[feed(theme: theme)],
               ),
             ),
           ],


### PR DESCRIPTION
# Description

Passed ThemeNotifier to home.dart so that feed() has access to the current theme. The text and icon colour of the nearby listing cards will change depending on the current theme. This fixes the colour issue in dark mode.

Fixes https://github.com/Runbhumi/Runbhumi/issues/93

## Type of change

Please choose the relavant type of change.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other

# How Has This Been Tested?

Tested on my physical device by manually forcing theme changes to verify that the colours indeed match their intended themes.

- [x] Test A: checked through my emulator.
- [ ] Test B: Firebase testing labs
- [x] Test C: Test through flutter test code
- [ ] Test D: Other (Please specify)

**Test Configuration**:
* Firmware version:
* Hardware: Pixel 2
* Toolchain:
* SDK: Flutter 1.22.1

# Checklist:

- [x] My code follows the style guidelines of this application
- [x] I have checked the code working on my emulator
- [x] I have commented my code for better understanding
- [x] These changes generate no new warnings
- [x] These changes do not effect the existing functionalities, 